### PR TITLE
Added possibility to turn off integrand evaluation in vegas and madnis integrator and vegas

### DIFF
--- a/madnis/integrator/integrator.py
+++ b/madnis/integrator/integrator.py
@@ -811,6 +811,7 @@ class Integrator(nn.Module):
         train: bool = False,
         channel_weight_mode: Literal["variance", "mean"] = "variance",
         channel: int | None = None,
+        evaluate_integrand: bool = True,
     ) -> SampleBatch:
         """
         Draws samples from the flow and evaluates the integrand
@@ -824,6 +825,8 @@ class Integrator(nn.Module):
             channel_weight_mode: specifies whether the channels are weighted by their mean or
                 variance. Note that weighting by mean can lead to problems for non-positive functions
             channel: if different from None, samples are only generated for this channel
+            evaluate_integrand: If False, the integrand is not evaluated and weight, y and alphas_prior are set to dummy values. This can be used when integrand
+                is expensive and one only needs the flow prob.
         Returns:
             Object containing a batch of samples
         """
@@ -873,7 +876,12 @@ class Integrator(nn.Module):
                         device=self.dummy.device,
                         dtype=self.dummy.dtype,
                     )
-                weight, y, alphas_prior = self.integrand(x, channels)
+                if evaluate_integrand:
+                    weight, y, alphas_prior = self.integrand(x, channels)
+                else:
+                    weight = torch.zeros((x.shape[0]), device=x.device, dtype=x.dtype)
+                    y = None
+                    alphas_prior = None
 
                 if self.group_channels and not self.group_channels_uniform:
                     chan_in_group = x[:, self.channel_group_dim].long()

--- a/madnis/integrator/vegas_pretraining.py
+++ b/madnis/integrator/vegas_pretraining.py
@@ -310,6 +310,7 @@ class VegasPreTraining:
         batch_size: int = 100000,
         channel_weight_mode: Literal["uniform", "mean", "variance"] = "variance",
         channel: int | None = None,
+        evaluate_integrand: bool = True,
     ) -> SampleBatch:
         """
         Draws samples and computes their integration weight
@@ -321,6 +322,8 @@ class VegasPreTraining:
                 variance or uniformly. Note that weighting by mean can lead to problems for
                 non-positive functions
             channel: if different from None, samples are only generated for this channel
+            evaluate_integrand: If False, the integrand is not evaluated and func_vals, y and alphas are set to dummy values. This can be used when integrand
+                is expensive and one only needs the mapping jacobian.
         Returns:
             ``SampleBatch`` object, see its documentation for details
         """
@@ -374,15 +377,21 @@ class VegasPreTraining:
             else:
                 channels = None
 
-            func_vals, y, alphas = self.integrand(
-                x_torch,
-                (
-                    channels
-                    if not self.integrator.group_channels
-                    or self.integrator.group_channels_uniform
-                    else integration_channels
-                ),
-            )
+            if evaluate_integrand:
+                func_vals, y, alphas = self.integrand(
+                    x_torch,
+                    (
+                        channels
+                        if not self.integrator.group_channels
+                        or self.integrator.group_channels_uniform
+                        else integration_channels
+                    ),
+                )
+            else:
+                func_vals = torch.zeros((x.shape[0]), dtype=self.integrator.dummy.dtype)
+                y = torch.zeros_like(x_torch)
+                alphas = torch.zeros_like(x_torch)
+
             if (
                 self.integrator.group_channels
                 and not self.integrator.group_channels_uniform


### PR DESCRIPTION
Modified:
- In `madnis/integrator/integrator.py`: `Integrator._get_samples()` to accomodate `evaluate_integrand()` flag.
- n `madnis/integrator/vegas_pretraining.py`: `VegasPreTraining.sample()` to accomodate `evaluate_integrand()` flag.