### PR TITLE
Correction to bug in evaluate_integrand=False

### DIFF
--- a/madnis/integrator/integrand.py
+++ b/madnis/integrator/integrand.py
@@ -29,6 +29,7 @@ class Integrand(nn.Module):
         discrete_prior_prob_function: (
             Callable[[torch.Tensor, int], torch.Tensor] | None
         ) = None,
+        function_dummy: Callable | None = None,
     ):
         """
         Args:
@@ -78,7 +79,7 @@ class Integrand(nn.Module):
         self.discrete_dims = discrete_dims
         self.discrete_dims_position = discrete_dims_position
         self.discrete_prior_prob_function = discrete_prior_prob_function
-
+        self.function_dummy = function_dummy
         if function_includes_sampling:
             self.function = function
         elif channel_count is None:

--- a/madnis/integrator/integrator.py
+++ b/madnis/integrator/integrator.py
@@ -879,9 +879,8 @@ class Integrator(nn.Module):
                 if evaluate_integrand:
                     weight, y, alphas_prior = self.integrand(x, channels)
                 else:
-                    weight = torch.zeros((x.shape[0]), device=x.device, dtype=x.dtype)
-                    y = None
-                    alphas_prior = None
+                    weight, y, alphas_prior = self.integrand.function_dummy(x, channels)
+                    weight = torch.ones((x.shape[0]), device=x.device, dtype=x.dtype)
 
                 if self.group_channels and not self.group_channels_uniform:
                     chan_in_group = x[:, self.channel_group_dim].long()
@@ -1112,6 +1111,7 @@ class Integrator(nn.Module):
         batch_size: int = 100000,
         channel_weight_mode: Literal["uniform", "mean", "variance"] = "variance",
         channel: int | None = None,
+        evaluate_integrand: bool = True,
     ) -> SampleBatch:
         """
         Draws samples and computes their integration weight
@@ -1140,6 +1140,7 @@ class Integrator(nn.Module):
                 False,
                 channel_weight_mode,
                 channel,
+                evaluate_integrand=evaluate_integrand,
             )
             if self.multichannel:
                 with torch.no_grad():


### PR DESCRIPTION
add function_dummy in order to avoid calling the cross section integrand, but still evaluating the useful multichannel configurations like alpha values; useful only in the evaluate_integrand=False case